### PR TITLE
feat: recovery shim sub-project scaffold (P2 skeleton)

### DIFF
--- a/recovery/platformio.ini
+++ b/recovery/platformio.ini
@@ -1,0 +1,58 @@
+; ForkDrift recovery shim — P2 of plan-trmnl-coexistence.md.
+;
+; Stripped Arduino-ESP32 app that lives in the 256 KB factory partition
+; of the coexist layout (see ../partitions-coexist.csv). Job: restore
+; either app slot from /.crosspoint/dashboard/ on SD when invoked.
+;
+; Build:   pio run -d crosspoint-reader/recovery
+; Output:  .pio/build/recovery/firmware.bin (this becomes factory.bin)
+;
+; Size budget: hard fail at 240 KB. Factory partition is 256 KB; we leave
+; 16 KB headroom for ESP32 image padding + future growth.
+;
+; This sub-project is intentionally separate from the main ForkDrift
+; PIO project so its lib_deps, build_flags, and source set stay minimal.
+; It DOES borrow HAL classes from ../lib/hal — see lib_extra_dirs below.
+
+[platformio]
+default_envs = recovery
+build_cache_dir = .cache
+
+[env:recovery]
+platform = espressif32 @ 6.12.0
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+
+board_upload.flash_size = 16MB
+
+build_unflags =
+  -fexceptions
+  -std=gnu++11
+
+build_flags =
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DRECOVERY_SHIM=1
+  -std=gnu++2a
+  -fno-exceptions
+  -Os
+  -ffunction-sections
+  -fdata-sections
+  -Wl,--gc-sections
+
+extra_scripts =
+  post:scripts/check_size.py
+
+; HAL classes (HalStorage, HalDisplay, HalGPIO) live in the parent project.
+; Reuse them rather than duplicating; keeps the shim aligned with ForkDrift's
+; HW abstractions. We pin only the libs the shim actually needs.
+lib_extra_dirs =
+  ../lib
+
+lib_deps =
+  ; Filled in during P2. Likely subset of:
+  ;   SDCardManager (open-x4-sdk symlink)
+  ;   EInkDisplay (open-x4-sdk symlink)
+  ;   HalStorage, HalDisplay (pulled via lib_extra_dirs)

--- a/recovery/scripts/check_size.py
+++ b/recovery/scripts/check_size.py
@@ -1,0 +1,61 @@
+"""
+Recovery shim size budget enforcement.
+
+Runs as a PlatformIO post-build step. Fails the build if the produced
+firmware.bin exceeds the budget. The budget exists because the shim
+must fit in the 256 KB factory partition with headroom for ESP32
+image padding and future growth.
+
+Tunable via env var RECOVERY_SHIM_MAX_BYTES (default 245760 = 240 KB).
+"""
+
+import os
+import sys
+
+Import("env")  # noqa: F821  — PlatformIO SCons global
+
+DEFAULT_MAX_BYTES = 240 * 1024  # 240 KB
+HARD_PARTITION_BYTES = 256 * 1024  # factory partition is 256 KB
+
+max_bytes = int(os.environ.get("RECOVERY_SHIM_MAX_BYTES", DEFAULT_MAX_BYTES))
+
+
+def check_size(source, target, env):  # noqa: ARG001 — SCons signature
+    bin_path = str(target[0])
+    try:
+        size = os.path.getsize(bin_path)
+    except OSError as e:
+        print(f"[recovery size-check] could not stat {bin_path}: {e}",
+              file=sys.stderr)
+        env.Exit(1)
+        return
+
+    headroom = max_bytes - size
+    pct = (size / HARD_PARTITION_BYTES) * 100
+    print(
+        f"[recovery size-check] {bin_path}: "
+        f"{size} B ({pct:.1f}% of 256 KB factory partition); "
+        f"budget {max_bytes} B; headroom {headroom} B"
+    )
+
+    if size > max_bytes:
+        print(
+            f"[recovery size-check] FAIL: shim exceeds {max_bytes} B budget "
+            f"by {size - max_bytes} B. Strip code or raise "
+            f"RECOVERY_SHIM_MAX_BYTES (current cap is the 256 KB partition).",
+            file=sys.stderr,
+        )
+        env.Exit(1)
+        return
+
+    if size > HARD_PARTITION_BYTES:
+        # Defense in depth — should be unreachable while max_bytes < HARD.
+        print(
+            f"[recovery size-check] FATAL: shim larger than factory "
+            f"partition ({size} > {HARD_PARTITION_BYTES}). Cannot flash.",
+            file=sys.stderr,
+        )
+        env.Exit(1)
+
+
+env.AddPostAction("$BUILD_DIR/firmware.bin", check_size)  # noqa: F821

--- a/recovery/src/main.cpp
+++ b/recovery/src/main.cpp
@@ -1,0 +1,31 @@
+// ForkDrift recovery shim — P2 skeleton.
+//
+// At this stage the shim does nothing functional: it boots, prints a
+// banner over USB-CDC, and idles. The purpose of this skeleton is to
+// confirm the build chain works end-to-end (toolchain, partitions,
+// size budget) before P2 implementation lands.
+//
+// See plan-trmnl-coexistence.md, Phase P2 for the full feature set.
+
+#include <Arduino.h>
+
+namespace {
+
+constexpr const char* BANNER = "ForkDrift recovery shim v0 (skeleton — no recovery logic yet)";
+
+}  // namespace
+
+void setup() {
+  Serial.begin(115200);
+  // Wait briefly for USB-CDC enumeration so the banner is visible.
+  for (uint32_t start = millis(); !Serial && millis() - start < 1000;) {
+    delay(10);
+  }
+  Serial.println(BANNER);
+}
+
+void loop() {
+  // Idle. P2 implementation will replace this with: mount SD, parse
+  // manifest, restore slots, set boot, restart.
+  delay(1000);
+}


### PR DESCRIPTION
## Summary

Stacked on top of #28. Scaffolds a separate PIO sub-project at \`recovery/\` that will become the factory-partition recovery shim.

This PR is **scaffolding only** — the shim boots, prints a banner, and idles. SD/manifest/OTA logic lands in the P2 implementation pass after the P1 stability bake (#28) is clean.

## Why a sub-project?

The shim has fundamentally different constraints than ForkDrift: no fonts, no I18n, no UITheme, hard 240 KB size budget, minimal lib_deps. Keeping it in its own project keeps those constraints enforceable and prevents accidental dependency drift from ForkDrift code.

It still reuses HAL classes via \`lib_extra_dirs = ../lib\` to stay aligned with ForkDrift's hardware abstractions.

## Changes

- \`recovery/platformio.ini\`: ESP32-C3 dev env, \`-DRECOVERY_SHIM=1\`, post-build size check
- \`recovery/src/main.cpp\`: minimal Arduino sketch (banner + idle loop)
- \`recovery/scripts/check_size.py\`: post-build assertion, hard fail above 240 KB (factory partition is 256 KB; 16 KB headroom for image padding)

## Build

\`\`\`
pio run -d crosspoint-reader/recovery
\`\`\`

Output: \`.pio/build/recovery/firmware.bin\` — this becomes \`factory.bin\` in P2.

## Test plan

- [x] Sub-project builds in isolation
- [x] Size check fires (try \`RECOVERY_SHIM_MAX_BYTES=10000\` to verify failure path)
- [ ] Hardware: flash to factory partition manually (esptool), invoke via \`esp_ota_set_boot_partition\`, observe banner over USB-CDC

## Stacked PRs

1. #27 — toggle (T1–T8)
2. #28 — coexist partitions (P1)
3. **#this** — recovery shim scaffold (P2 skeleton)

## Notes for reviewers

This PR introduces no behavioral change to ForkDrift. The sub-project produces an artifact that isn't yet flashed to any device. P2 implementation (mount SD, parse manifest, restore slots) is a separate PR after P1's stability bake.